### PR TITLE
fix: Ensure users are removed from waiting pool on cancel

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -317,7 +317,22 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // === MATCHMAKING KUYRUK & İSTATİSTİKLER ===
+    // === MATCHMAKING ===
+    match /waiting_pool/{userId} {
+      // A user can delete their own entry from the pool (e.g. when cancelling).
+      allow delete: if request.auth.uid == userId;
+      // No other client-side access is permitted.
+      allow read, create, update: if false;
+    }
+
+    match /matches/{userId} {
+      // A user can read and delete their own match document.
+      allow read, delete: if request.auth.uid == userId;
+      // The server creates the match, clients cannot create or update.
+      allow create, update: if false;
+    }
+
+    // === DEPRECATED OR SERVER-ONLY MATCHMAKING RULES ===
     // Kuyruk shard dokümanlarına istemci direkt erişemez (yalnızca Cloud Functions Admin SDK)
     match /match_queue_shards/{shardId} {
       match /entries/{userId} {
@@ -334,6 +349,5 @@ service cloud.firestore {
       allow read: if isAuthenticated() && isPrivileged(request.auth.uid);
       allow write: if false;
     }
-    // === /MATCHMAKING ===
   }
 }


### PR DESCRIPTION
Added Firestore security rules for the `waiting_pool` and `matches` collections. Previously, no rules were defined, so the client's request to delete their document from the `waiting_pool` on search cancellation was being denied by default.

The new rules explicitly allow a user to delete their own document from both `waiting_pool` and the `matches` notification collection, fixing the bug where users would get stuck in the matchmaking pool after cancelling.