### PR TITLE
fix: Always create a new chat room for each match

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -755,7 +755,7 @@ exports.findMatch = functions
               const idA = myId < otherId ? myId : otherId;
               const idB = myId < otherId ? otherId : myId;
 
-              const chatRoomRef = db.collection("chats").doc(`${idA}_${idB}`);
+              const chatRoomRef = db.collection("chats").doc();
               tx.set(chatRoomRef, {
                 users: [idA, idB],
                 userDetails: {
@@ -771,7 +771,7 @@ exports.findMatch = functions
                 },
                 status: "active",
                 createdAt: admin.firestore.FieldValue.serverTimestamp(),
-              }, {merge: true}); // Use merge to avoid overwriting existing chat
+              });
 
               // Eşleşme bildirimlerini oluştur
               const matchData = {


### PR DESCRIPTION
Reverted the chat room creation logic to use a unique, auto-generated document ID for each new chat.

Previously, a deterministic ID was created based on the users' UIDs. This caused old chats to be reopened when the same two users were matched again, which was not the desired behavior. This also caused confusion during testing, making it seem like the waiting pool was not working correctly.

This change ensures that every match results in a fresh, new chat room.