### PR TITLE
fix: Implement symmetrical match notification system

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -146,15 +146,14 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
       final status = response.data['status'];
 
-      if (status == 'MATCH_FOUND') {
-        final chatId = response.data['chatId'];
-        _navigateToChat(chatId);
-      } else if (status == 'ADDED_TO_POOL') {
-        // User is in the waiting pool, start listening for a match
+      if (status == 'ADDED_TO_POOL' || status == 'MATCH_PROCESSED') {
+        // In both cases, the user should listen for a match document.
+        // If they were added to the pool, they wait for someone else.
+        // If a match was processed, their own match document was just created.
         _listenForMatch();
       } else {
         // Handle other statuses or errors
-        throw Exception(response.data['message'] ?? 'Unknown error');
+        throw Exception(response.data['message'] ?? 'Unknown error from server');
       }
     } on FirebaseFunctionsException catch (e) {
       if (mounted) {


### PR DESCRIPTION
Refactored the matchmaking flow to use a symmetrical notification system, ensuring both users in a match are notified at the same time.

Previously, the calling user received an immediate HTTP response, while the waiting user relied on a slower database listener, causing a noticeable delay for one user.

Now, the `findMatch` function returns a generic success status. Both clients are responsible for listening to a new `matches/{userId}` document, which is created for both users simultaneously within the match transaction. This eliminates the race condition and provides a seamless user experience.