### PR TITLE
fix!: Simplify and stabilize matchmaking with Firestore-only listeners

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -707,7 +707,7 @@ exports.findMatch = functions
       // --- Adım 2: Eşleştirme Mantığı (İşlem İçinde) ---
       try {
         const result = await db.runTransaction(async (tx) => {
-          let finalResult = {status: "ADDED_TO_POOL", fcmData: null};
+          let finalStatus = {status: "ADDED_TO_POOL"};
 
           // Adım 2a: Potansiyel eşleşmeleri doğrula
           for (const partnerDoc of potentialPartnerDocs) {
@@ -758,23 +758,14 @@ exports.findMatch = functions
               const myWaitingRef = db.collection("waiting_pool").doc(myId);
               tx.delete(myWaitingRef);
 
-              // Eşleşme yapıldı, sonucu ayarla ve döngüden çık.
-              finalResult = {
-                status: "MATCH_PROCESSED",
-                fcmData: {
-                  chatId: chatRoomRef.id,
-                  tokens: [
-                    ...(myData.fcmTokens || []),
-                    ...(partnerData.fcmTokens || []),
-                  ].filter((t) => t), // Null/undefined token'ları temizle
-                },
-              };
+              // Eşleşme yapıldı, durumu güncelle ve döngüden çık.
+              finalStatus = {status: "MATCH_PROCESSED"};
               break;
             }
           }
 
           // Döngüden sonra, eğer eşleşme bulunmadıysa, kullanıcıyı havuza ekle.
-          if (finalResult.status === "ADDED_TO_POOL") {
+          if (finalStatus.status === "ADDED_TO_POOL") {
             const waitingPoolRef = db.collection("waiting_pool").doc(myId);
             tx.set(waitingPoolRef, {
               ...myPublicData,
@@ -784,26 +775,10 @@ exports.findMatch = functions
             });
           }
 
-          return finalResult;
+          return finalStatus;
         });
 
-        // Adım 3: FCM Bildirimini Gönder (İşlem Sonrası)
-        if (result.status === "MATCH_PROCESSED" && result.fcmData && result.fcmData.tokens.length > 0) {
-          const {chatId, tokens} = result.fcmData;
-          const message = {
-            data: {
-              type: "MATCH_FOUND",
-              chatId: chatId,
-              click_action: "FLUTTER_NOTIFICATION_CLICK",
-            },
-            tokens: tokens,
-          };
-          admin.messaging().sendEachForMulticast(message).catch((error) => {
-            console.error("Error sending match notification FCM:", error);
-          });
-        }
-
-        return {status: result.status}; // İstemciye sadece durumu gönder
+        return result; // İstemciye sonucu olduğu gibi gönder
       } catch (error) {
         console.error("Matchmaking transaction failed:", error);
         throw new functions.https.HttpsError("internal", "Matchmaking failed, please try again.");

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -12,7 +12,6 @@ import 'package:lingua_chat/widgets/home_screen/searching_ui.dart';
 import 'package:lingua_chat/widgets/home_screen/stats_row.dart';
 import 'package:lingua_chat/widgets/home_screen/premium_upsell_dialog.dart';
 import 'package:lingua_chat/widgets/home_screen/partner_finder_section.dart';
-import 'package:lingua_chat/services/notification_service.dart';
 import 'package:lingua_chat/widgets/home_screen/home_cards_section.dart';
 import 'package:lingua_chat/widgets/common/safety_help_button.dart';
 
@@ -28,7 +27,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   final _currentUser = FirebaseAuth.instance.currentUser;
   bool _isSearching = false;
   StreamSubscription? _matchListener;
-  StreamSubscription? _fcmMatchSub; // FCM listener
   Stream<DocumentSnapshot<Map<String, dynamic>>>? _userStream;
 
   String? _selectedGenderFilter;
@@ -65,14 +63,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     _setupAnimations();
     _startCardScrollTimer();
     _entryAnimationController.forward();
-
-    // Listen for match notifications from FCM
-    _fcmMatchSub = onMatchFound.listen((chatId) {
-      if (mounted && _isSearching) {
-        debugPrint("Match found via FCM, navigating to chat: $chatId");
-        _navigateToChat(chatId);
-      }
-    });
   }
 
   void _startCardScrollTimer() {
@@ -101,7 +91,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   @override
   void dispose() {
     _matchListener?.cancel();
-    _fcmMatchSub?.cancel();
     _cardScrollTimer?.cancel();
     _entryAnimationController.dispose();
     _pulseAnimationController.dispose();


### PR DESCRIPTION
This commit resolves all known matchmaking issues by removing the complex and unreliable FCM hybrid system and implementing a simpler, more robust architecture based solely on Firestore listeners.

The previous hybrid approach (FCM + Firestore) caused unpredictable asymmetrical delays, where one user would be notified of a match faster than the other.

This new, simplified system ensures a symmetrical experience:
1. The `findMatch` Cloud Function no longer sends FCM messages. Its only job is to atomically update the Firestore database (`chats`, `matches`, and `waiting_pool` collections).
2. The client has been simplified to rely *only* on a listener for the `matches/{userId}` document.
3. This ensures both users in a match are notified via the exact same mechanism and at the same time (within Firestore's latency), eliminating the "one user is stuck" problem.