### PR TITLE
fix(firestore): Allow member updates in group chats to prevent permis…

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -221,7 +221,7 @@ service cloud.firestore {
             get(/databases/$(database)/documents/group_chats/$(roomId)).data.ownerId == request.auth.uid
         );
         allow delete: if callerNotBanned() && isAuthenticated() && (isOwner(userId) || isPrivileged(request.auth.uid) || (exists(/databases/$(database)/documents/group_chats/$(roomId)) && get(/databases/$(database)/documents/group_chats/$(roomId)).data.ownerId == request.auth.uid));
-        allow update: if false;
+        allow update: if isOwner(userId) && callerNotBanned();
       }
 
       match /messages/{messageId} {


### PR DESCRIPTION
…sion error

The `group_chat_screen.dart` calls `.set()` on a user's member document every time the user enters the chat. For an existing member, this is an `update` operation.

The previous security rule `allow update: if false;` for `group_chats/{roomId}/members/{userId}` was too restrictive, causing a 'permission denied' error when a user re-entered a chat. This error was caught by a generic handler that misleadingly reported 'user data could not be fetched'.

This change modifies the rule to `allow update: if isOwner(userId) && callerNotBanned();`, permitting users to update their own membership document. This resolves the underlying permission error that occurs on entering a group chat.